### PR TITLE
DEV: add jax-native build methods and test with jax

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - uses: RalfG/python-wheels-manylinux-build@v0.4.2
         with:
           python-versions: 'cp39-cp39 cp310-cp310 cp311-cp311'
@@ -36,9 +38,11 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -80,9 +84,11 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -108,9 +114,11 @@ jobs:
     needs: [ build-linux, build-other, build-dist ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Download artifact

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools setuptools_scm
-        python -m pip install cython oldest-supported-numpy
+        python -m pip install cython
     - name: Build wheel
       run: |
         python -m pip wheel -v --wheel-dir=wheel --no-deps .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         # setup requirements
         conda install cython numpy
         # testing requirements
-        conda install pytest-cov pre-commit scipy
+        conda install pytest-cov pre-commit scipy jax
         python -m pip install --upgrade pip setuptools
     - name: Install package
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,19 @@ jobs:
       max-parallel: 5
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-        conda config --add channels conda-forge
+    - name: Setup conda
+      uses: s-weigand/setup-conda@v1
+      with:
+        update-conda: true
+        python-version: ${{ matrix.python-version }}
+        conda-channels: anaconda, conda-forge
     - name: Install dependencies
       run: |
         # setup requirements

--- a/cached_interpolate/build.pyx
+++ b/cached_interpolate/build.pyx
@@ -52,7 +52,7 @@ cpdef build_natural_cubic_spline(double[:] xx, numeric[:] yy):
     for jj in range(n_points - 1, -1, -1):
         c_[jj] = z_[jj] - m_[jj] * _c
         b_[jj] = (
-            (y_[jj + 1] - y_[jj]) / de[jj]
+            (yy[jj + 1] - yy[jj]) / de[jj]
             - de[jj] * (_c + 2 * c_[jj]) / 3
         )
         d_[jj] = (_c - c_[jj]) / 3 / de[jj]

--- a/cached_interpolate/build.pyx
+++ b/cached_interpolate/build.pyx
@@ -1,6 +1,10 @@
 cimport numpy as np  # noqa
 import numpy as np
 
+ctypedef fused numeric:
+    complex
+    double
+
 
 cpdef build_linear_interpolant(xx, yy):
     aa = yy[:len(xx) - 1]
@@ -8,47 +12,50 @@ cpdef build_linear_interpolant(xx, yy):
     return aa, bb
 
 
-cpdef build_natural_cubic_spline(xx, yy):
+cpdef build_natural_cubic_spline(double[:] xx, numeric[:] yy):
     cdef int ii, jj
     cdef int n_points = len(xx) - 1
-    cdef double ll, _c
+    cdef numeric ll, _c
 
     aa = yy.copy()[:n_points]
-    bb = np.empty(n_points)
-    cc = np.empty(n_points)
-    dd = np.empty(n_points)
+    bb = np.empty_like(aa)
+    cc = np.empty_like(aa)
+    dd = np.empty_like(aa)
 
     delta = np.diff(xx)
 
     alpha = 3 * np.diff(np.diff(yy) / delta)
 
-    mu = np.empty(n_points + 1)
-    zz = np.empty(n_points)
+    mu = np.empty_like(yy)
+    zz = np.empty_like(aa)
 
-    cdef double[:] a_ = aa
-    cdef double[:] b_ = bb
-    cdef double[:] c_ = cc
-    cdef double[:] d_ = dd
-    cdef double[:] m_ = mu
+    cdef numeric[:] a_ = aa
+    cdef numeric[:] b_ = bb
+    cdef numeric[:] c_ = cc
+    cdef numeric[:] d_ = dd
+    cdef numeric[:] m_ = mu
     cdef double[:] x_ = xx
-    cdef double[:] z_ = zz
-    cdef double[:] al = alpha
+    cdef numeric[:] z_ = zz
+    cdef numeric[:] al = alpha
     cdef double[:] de = delta
 
-    m_[0] = 0
-    z_[0] = 0
+    m_[0] = 0.0
+    z_[0] = 0.0
 
     for ii in range(1, n_points):
         ll = 2 * (x_[ii + 1] - x_[ii - 1]) - de[ii - 1] * m_[ii - 1]
         m_[ii] = de[ii] / ll
         z_[ii] = (al[ii - 1] - de[ii - 1] * z_[ii - 1]) / ll
 
-    _c = 0
+    _c = 0.0
 
     for jj in range(n_points - 1, -1, -1):
         c_[jj] = z_[jj] - m_[jj] * _c
-        b_[jj] = (a_[jj + 1] - a_[jj]) / de[jj] - de[jj] * (_c + 2 * c_[jj]) / 3
+        b_[jj] = (
+            (y_[jj + 1] - y_[jj]) / de[jj]
+            - de[jj] * (_c + 2 * c_[jj]) / 3
+        )
         d_[jj] = (_c - c_[jj]) / 3 / de[jj]
         _c = c_[jj]
 
-    return aa, bb, cc, dd
+    return np.array(aa), bb, cc, dd

--- a/cached_interpolate/build_jax.py
+++ b/cached_interpolate/build_jax.py
@@ -1,0 +1,39 @@
+import jax.numpy as jnp
+from jax import jit
+
+
+@jit
+def build_linear_interpolant(xx, yy):
+    aa = yy[: len(xx) - 1]
+    bb = jnp.diff(yy) / jnp.diff(xx)
+    return aa, bb
+
+
+@jit
+def build_natural_cubic_spline(xx, yy):
+    n_points = len(xx) - 1
+    aa = yy.copy()[:n_points]
+
+    delta = jnp.diff(xx)
+    alpha = 3 * jnp.diff(jnp.diff(yy) / delta)
+
+    mu = jnp.zeros_like(yy)
+    zz = jnp.zeros_like(aa)
+    for ii in range(1, n_points):
+        ll = 2 * (xx[ii + 1] - xx[ii - 1]) - delta[ii - 1] * mu[ii - 1]
+        mu = mu.at[ii].set(delta[ii] / ll)
+        zz = zz.at[ii].set((alpha[ii - 1] - delta[ii - 1] * zz[ii - 1]) / ll)
+
+    bb = jnp.zeros_like(aa)
+    cc = jnp.zeros_like(aa)
+    dd = jnp.zeros_like(aa)
+    c_old = 0
+    for jj in range(n_points - 1, -1, -1):
+        cc = cc.at[jj].set(zz[jj] - mu[jj] * c_old)
+        bb = bb.at[jj].set(
+            (yy[jj + 1] - yy[jj]) / delta[jj] - delta[jj] * (c_old + 2 * cc[jj]) / 3
+        )
+        dd = dd.at[jj].set((c_old - cc[jj]) / 3 / delta[jj])
+        c_old = cc[jj]
+
+    return aa, bb, cc, dd

--- a/cached_interpolate/test/conftest.py
+++ b/cached_interpolate/test/conftest.py
@@ -1,0 +1,27 @@
+import importlib
+
+import pytest
+
+from cached_interpolate import CachingInterpolant, RegularCachingInterpolant
+
+interpolants = [RegularCachingInterpolant, CachingInterpolant]
+
+
+@pytest.fixture(params=interpolants)
+def interpolant(request):
+    return request.param
+
+
+@pytest.fixture(params=["nearest", "linear", "cubic"])
+def kind(request):
+    return request.param
+
+
+@pytest.fixture(params=["numpy", "jax.numpy", "cupy"])
+def backend(request):
+    pytest.importorskip(request.param)
+    if "jax" in request.param:
+        import jax
+
+        jax.config.update("jax_enable_x64", True)
+    return importlib.import_module(request.param)

--- a/cached_interpolate/test/interpolate_test.py
+++ b/cached_interpolate/test/interpolate_test.py
@@ -1,21 +1,19 @@
-from itertools import product
-
 import numpy as np
 import pytest
 from scipy.interpolate import CubicSpline, interp1d
 
-from cached_interpolate import CachingInterpolant, RegularCachingInterpolant
-
-interpolants = [RegularCachingInterpolant, CachingInterpolant]
+from cached_interpolate import RegularCachingInterpolant
 
 
 @pytest.mark.parametrize("bc_type", ["clamped", "natural", "not-a-knot", "periodic"])
-def test_cubic_matches_scipy(bc_type):
+def test_cubic_matches_scipy(bc_type, backend):
     x_values = np.linspace(0, 1, 10)
     y_values = np.random.uniform(-1, 1, 10)
     if bc_type == "periodic":
         y_values[0] = y_values[-1]
-    spl = RegularCachingInterpolant(x_values, y_values, kind="cubic", bc_type=bc_type)
+    spl = RegularCachingInterpolant(
+        x_values, y_values, kind="cubic", bc_type=bc_type, backend=backend
+    )
     test_points = np.random.uniform(0, 1, 10000)
     max_diff = 0
     for _ in range(100):
@@ -28,7 +26,6 @@ def test_cubic_matches_scipy(bc_type):
     assert max_diff, 1e-10
 
 
-@pytest.mark.parametrize("interpolant", interpolants)
 def test_caching_interpolant_bad_bc_type(interpolant):
     x_values = np.linspace(0, 1, 10)
     y_values = np.random.uniform(-1, 1, 10)
@@ -36,11 +33,10 @@ def test_caching_interpolant_bad_bc_type(interpolant):
         _ = interpolant(x_values, y_values, kind="cubic", bc_type="bad")
 
 
-@pytest.mark.parametrize("interpolant", interpolants)
-def test_nearest_matches_scipy(interpolant):
+def test_nearest_matches_scipy(interpolant, backend):
     x_values = np.linspace(0, 1, 10)
     y_values = np.random.uniform(-1, 1, 10)
-    spl = interpolant(x_values, y_values, kind="nearest")
+    spl = interpolant(x_values, y_values, kind="nearest", backend=backend)
     test_points = np.random.uniform(0, 1, 10000)
     max_diff = 0
     for _ in range(100):
@@ -51,11 +47,10 @@ def test_nearest_matches_scipy(interpolant):
     assert max_diff < 1e-10
 
 
-@pytest.mark.parametrize("interpolant", interpolants)
-def test_linear_matches_numpy(interpolant):
+def test_linear_matches_numpy(interpolant, backend):
     x_values = np.linspace(0, 1, 10)
     y_values = np.random.uniform(-1, 1, 10)
-    spl = interpolant(x_values, y_values, kind="linear")
+    spl = interpolant(x_values, y_values, kind="linear", backend=backend)
     test_points = np.random.uniform(0, 1, 10000)
     max_diff = 0
     for _ in range(100):
@@ -66,42 +61,37 @@ def test_linear_matches_numpy(interpolant):
     assert max_diff < 1e-10
 
 
-@pytest.mark.parametrize("interpolant", interpolants)
-def test_single_input(interpolant):
+def test_single_input(interpolant, backend):
     x_values = np.linspace(0, 1, 10)
     y_values = np.random.uniform(-1, 1, 10)
-    spl = interpolant(x_values, y_values, kind="cubic")
+    spl = interpolant(x_values, y_values, kind="cubic", backend=backend)
     assert spl(0) == y_values[0]
 
 
-@pytest.mark.parametrize("interpolant", interpolants)
-def test_single_complex(interpolant):
+def test_single_complex(interpolant, backend):
     x_values = np.linspace(0, 1, 10)
     y_values = np.random.uniform(-1, 1, 10)
     y_values = y_values + 1j * (1 - y_values)
-    spl = CachingInterpolant(x_values, y_values, kind="cubic")
+    spl = interpolant(x_values, y_values, kind="cubic", backend=backend)
     assert spl(0) == y_values[0]
 
 
-@pytest.mark.parametrize("interpolant", interpolants)
-def test_interpolation_at_lower_bound(interpolant):
+def test_interpolation_at_lower_bound(interpolant, backend):
     x_values = np.linspace(0, 1, 10)
     y_values = np.random.uniform(-1, 1, 10)
-    spl = interpolant(x_values, y_values, kind="cubic")
+    spl = interpolant(x_values, y_values, kind="cubic", backend=backend)
     test_point = 0
     assert abs(spl(test_point) - y_values[0]) < 1e-5
 
 
-@pytest.mark.parametrize("interpolant", interpolants)
-def test_interpolation_at_upper_bound(interpolant):
+def test_interpolation_at_upper_bound(interpolant, backend):
     x_values = np.linspace(0, 1, 10)
     y_values = np.random.uniform(-1, 1, 10)
-    spl = interpolant(x_values, y_values, kind="cubic")
+    spl = interpolant(x_values, y_values, kind="cubic", backend=backend)
     test_point = 1
     assert abs(spl(test_point) - y_values[-1]) < 1e-5
 
 
-@pytest.mark.parametrize("interpolant", interpolants)
 def test_bad_interpolation_method_raises_error(interpolant):
     x_values = np.linspace(0, 1, 10)
     y_values = np.random.uniform(-1, 1, 10)
@@ -109,53 +99,98 @@ def test_bad_interpolation_method_raises_error(interpolant):
         _ = interpolant(x_values, y_values, kind="bad method")
 
 
-@pytest.mark.parametrize("interpolant", interpolants)
-def test_running_without_new_y_values(interpolant):
+def test_running_without_new_y_values(interpolant, backend):
     x_values = np.linspace(0, 1, 10)
     y_values = np.random.uniform(-1, 1, 10)
-    spl = interpolant(x_values, y_values, kind="cubic")
+    spl = interpolant(x_values, y_values, kind="cubic", backend=backend)
     old_values = spl._data
-    _ = spl(np.array([0, 1]), y=np.random.uniform(-1, 1, 10), use_cache=False)
+    points = backend.asarray(np.random.uniform(-1, 1, 10))
+    _ = spl(np.array([0, 1]), y=points, use_cache=False)
     assert np.max(old_values - spl._data) > 1e-5
 
 
-@pytest.mark.parametrize("interpolant", interpolants)
-def test_running_with_complex_input_linear(interpolant):
+def test_running_with_complex_input_linear(interpolant, backend):
     x_values = np.linspace(0, 1, 10)
     y_values = np.random.uniform(-1, 1, 10)
     y_values = y_values * np.exp(1j * np.random.uniform(0, 2 * np.pi, 10))
-    spl = interpolant(x_values, y_values, kind="linear")
+    spl = interpolant(x_values, y_values, kind="linear", backend=backend)
     scs = interp1d(x=x_values, y=y_values, kind="linear")
-    test_points = np.random.uniform(0, 1, 10)
+    test_points = backend.asarray(np.random.uniform(0, 1, 10))
     scs_test = scs(test_points)
     diffs = spl(test_points) - scs_test
     assert np.max(diffs) < 1e-10
 
 
-@pytest.mark.parametrize("interpolant", interpolants)
-def test_running_with_complex_input_cubic(interpolant):
+def test_running_with_complex_input_cubic(interpolant, backend):
     x_values = np.linspace(0, 1, 10)
     y_values = np.random.uniform(-1, 1, 10)
     y_values = y_values * np.exp(1j * np.random.uniform(0, 2 * np.pi, 10))
-    spl = interpolant(x_values, y_values, kind="cubic", bc_type="natural")
+    spl = interpolant(
+        x_values, y_values, kind="cubic", bc_type="natural", backend=backend
+    )
     scs = CubicSpline(x=x_values, y=y_values, bc_type="natural")
-    test_points = np.random.uniform(0, 1, 10)
+    test_points = backend.asarray(np.random.uniform(0, 1, 10))
     scs_test = scs(test_points)
     diffs = spl(test_points) - scs_test
     assert np.max(diffs) < 1e-10
 
 
-@pytest.mark.parametrize(
-    "kind,interpolant", product(["nearest", "linear", "cubic"], interpolants)
-)
-def test_2d_input(kind, interpolant):
-    kwargs = dict(x=np.linspace(0, 1, 5), y=np.random.uniform(0, 1, 5), kind=kind)
-    test_values = np.random.uniform(0, 1, (2, 10000))
-    spl = CachingInterpolant(**kwargs)
+def test_2d_input(kind, interpolant, backend):
+    kwargs = dict(
+        x=np.linspace(0, 1, 5),
+        y=np.random.uniform(0, 1, 5),
+        kind=kind,
+        backend=backend,
+    )
+    test_values = backend.asarray(np.random.uniform(0, 1, (2, 10000)))
+    spl = interpolant(**kwargs)
     array_test = spl(test_values)
     loop_test = list()
     for ii in range(2):
-        spl = CachingInterpolant(**kwargs)
+        spl = interpolant(**kwargs)
         loop_test.append(spl(test_values[ii]))
     loop_test = np.array(loop_test)
     assert np.array_equal(loop_test, array_test)
+
+
+class _Foo:
+    """Dummy class to mimic how this is used in GWPopulation"""
+
+    def __init__(self, x, y, kind, backend, interpolant):
+        from functools import partial
+
+        self.interpolant = partial(
+            interpolant(x=x, y=x, kind=kind, backend=backend),
+            y,
+        )
+
+    def __call__(self, data):
+        self.interpolant(data)
+
+
+def test_caching_with_jax(kind, interpolant):
+    """
+    Create the interpolant and run a few times with various inputs and
+    compilation to test
+    https://github.com/ColmTalbot/cached_interpolation/issues/19
+    """
+    pytest.importorskip("jax")
+    import jax.numpy as jnp
+    from jax import jit
+
+    test_values = np.random.uniform(0, 1, (2, 10000))
+    kwargs = dict(
+        x=np.linspace(0, 1, 5),
+        y=test_values,
+        kind=kind,
+        backend=jnp,
+        interpolant=interpolant,
+    )
+    spl = _Foo(**kwargs)
+
+    test_values = np.asarray(np.random.uniform(0, 1, 5))
+    _ = spl(test_values)
+    test_values = jnp.asarray(test_values)
+    temp = jit(spl)
+    _ = temp(jnp.asarray(np.random.uniform(0, 1, 5)))
+    _ = temp(test_values)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools_scm[toml]>=3.4.3",
     "wheel",
     "cython",
-    "numpy",
+    "numpy>=2",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
I added a new module `build_jax` that translates the build cython code to python+jax, this should enable full compilation of the `CachingInterpolant` so that regular interpolants aren't required.

I also added JAX to the full test suite.

There were issues with JAX compilation and linear interpolation that are now fixed and tested for.

Closes https://github.com/ColmTalbot/cached_interpolation/issues/19