### PR TITLE
BUG: make sure cache is constructed with numpy arrays

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: RalfG/python-wheels-manylinux-build@v0.4.2
         with:
-          python-versions: 'cp39-cp39 cp310-cp310 cp311-cp311'
+          python-versions: 'cp310-cp310 cp311-cp311 cp312-cp312'
           build-requirements: 'cython numpy setuptools_scm'
           pip-wheel-args: '-v --wheel-dir=wheelhouse --no-deps'
       - uses: actions/upload-artifact@v3
@@ -32,8 +32,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        os: [windows-latest, macos-latest, macos=13]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, macos-13]
+        os: [windows-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, macos=13]
+        os: [windows-latest, macos-latest, macos-13]
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         python -m pip wheel -v --wheel-dir=wheel --no-deps .
     - name: Fix wheel (Mac OS)
-      if: statsWith(matrix.os, 'macos')
+      if: startsWith(matrix.os, 'macos')
       run: |
         python -m pip install delocate
         delocate-wheel -v -w wheelhouse wheel/cached_interpolate*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         python -m pip wheel -v --wheel-dir=wheel --no-deps .
     - name: Fix wheel (Mac OS)
-      if: matrix.os == 'macos-latest'
+      if: statsWith(matrix.os, 'macos')
       run: |
         python -m pip install delocate
         delocate-wheel -v -w wheelhouse wheel/cached_interpolate*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: RalfG/python-wheels-manylinux-build@v0.4.2
         with:
-          python-versions: 'cp310-cp310 cp311-cp311 cp312-cp312'
+          python-versions: 'cp310-cp310 cp311-cp311'
           build-requirements: 'cython numpy setuptools_scm'
           pip-wheel-args: '-v --wheel-dir=wheelhouse --no-deps'
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
       max-parallel: 5
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,6 @@ author = Colm Talbot
 author_email = colm.talbot@ligo.org
 license = MIT
 classifiers =
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -18,7 +17,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 [options]
-python_requires = >=3.9
+python_requires = >=3.10
 include_package_data = true
 packages =
     cached_interpolate


### PR DESCRIPTION
The simplest way to resolve this is to coerce everything into numpy format for the cache construction.

The cache construction shouldn't be called regularly by definition and can be much faster with numpy anyway.

Addresses #21